### PR TITLE
Import Mapping from collections.abc, not collections

### DIFF
--- a/password_store/credentials.py
+++ b/password_store/credentials.py
@@ -1,5 +1,5 @@
 from subprocess import run, PIPE
-from collections import Mapping
+from collections.abc import Mapping
 from typing import Tuple
 import yaml
 


### PR DESCRIPTION
The old `collections.Mapping` name was removed in Python 3.10.